### PR TITLE
feat: configure api base url

### DIFF
--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -46,7 +46,9 @@ export default defineConfig((/* ctx */) => {
 
       // publicPath: '/',
       // analyze: true,
-      // env: {},
+      env: {
+        API_BASE_URL: process.env.API_BASE_URL || 'http://localhost:8080/api',
+      },
       // rawDefine: {}
       // ignorePublicFolder: true,
       // minify: false,
@@ -74,6 +76,12 @@ export default defineConfig((/* ctx */) => {
     devServer: {
       // https: true,
       open: true, // opens browser window automatically
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8080',
+          changeOrigin: true,
+        },
+      },
     },
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#framework

--- a/frontend/src/boot/axios.js
+++ b/frontend/src/boot/axios.js
@@ -7,7 +7,9 @@ import axios from 'axios'
 // good idea to move this instance creation inside of the
 // "export default () => {}" function below (which runs individually
 // for each client)
-const api = axios.create({ baseURL: 'https://api.example.com' })
+const api = axios.create({
+  baseURL: process.env.API_BASE_URL || 'http://localhost:8080/api',
+})
 
 export default defineBoot(({ app }) => {
   // for use inside Vue files (Options API) through this.$axios and this.$api

--- a/frontend/src/pages/GamePage.vue
+++ b/frontend/src/pages/GamePage.vue
@@ -8,7 +8,7 @@
 
 <script setup>
 import { ref, onMounted, getCurrentInstance } from 'vue'
-import axios from 'axios'
+import { api } from 'boot/axios'
 import { useRoute } from 'vue-router'
 import { useGameStore } from 'stores/game'
 
@@ -18,7 +18,7 @@ const question = ref('')
 const answer = ref('')
 
 onMounted(async () => {
-  const { data } = await axios.get('/api/questions/random', {
+  const { data } = await api.get('/questions/random', {
     params: { lobbyId: route.params.id },
   })
   question.value = data.text

--- a/frontend/src/pages/LobbyCreatePage.vue
+++ b/frontend/src/pages/LobbyCreatePage.vue
@@ -10,7 +10,7 @@
 
 <script setup>
 import { ref } from 'vue'
-import axios from 'axios'
+import { api } from 'boot/axios'
 import { useRouter } from 'vue-router'
 
 const router = useRouter()
@@ -20,7 +20,7 @@ const roundSeconds = ref(120)
 const spectatorVoting = ref(true)
 
 const createLobby = async () => {
-  const { data } = await axios.post('/api/lobbies', {
+  const { data } = await api.post('/lobbies', {
     hostName: name.value,
     settings: {
       hearts: hearts.value,

--- a/frontend/src/pages/LobbyViewPage.vue
+++ b/frontend/src/pages/LobbyViewPage.vue
@@ -13,7 +13,7 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
-import axios from 'axios'
+import { api } from 'boot/axios'
 import { useRoute, useRouter } from 'vue-router'
 import { useGameStore } from 'stores/game'
 
@@ -24,7 +24,7 @@ const lobby = ref({ players: [] })
 const isHost = ref(false)
 
 onMounted(async () => {
-  const { data } = await axios.get(`/api/lobbies/${route.params.id}`)
+  const { data } = await api.get(`/lobbies/${route.params.id}`)
   lobby.value = data
   store.setLobby(data)
   isHost.value = data.players[0]?.id === store.player?.id


### PR DESCRIPTION
## Summary
- configure axios base URL via `API_BASE_URL` environment variable and export api client
- switch lobby and game pages to use shared api instance without `/api` prefix
- add dev server proxy for backend API

## Testing
- `npm test`
- `npm run lint`
- `npm run dev` *(terminated manually)*

------
https://chatgpt.com/codex/tasks/task_e_68a649655b348322a33d9026d2d259b1