### PR TITLE
feat: apply palenight dark gradient theme

### DIFF
--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -3,3 +3,15 @@ body {
   background: linear-gradient(180deg, #292d3e 0%, #1b1e2b 100%);
   color: #ffffff;
 }
+
+/* palenight header with dark gradient */
+.palenight-header {
+  background: linear-gradient(90deg, #292d3e 0%, #1b1e2b 100%);
+  color: #ffffff;
+}
+
+/* keep page content centered for better readability */
+.q-page {
+  max-width: 1200px;
+  margin: 0 auto;
+}

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,8 +1,8 @@
 <template>
   <q-layout view="lHh Lpr lFf">
-    <q-header elevated>
+    <q-header elevated class="palenight-header">
       <q-toolbar>
-        <q-toolbar-title>Der dümmste fliegt</q-toolbar-title>
+        <q-toolbar-title class="text-white">Der dümmste fliegt</q-toolbar-title>
       </q-toolbar>
     </q-header>
     <q-page-container>


### PR DESCRIPTION
## Summary
- style layout with reusable palenight header gradient
- center page content for more readable UI

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70f66b05c8322a18d7d8962b6f0a4