### PR TITLE
feat(ui): apply palenight gradient theme

### DIFF
--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -86,7 +86,9 @@ export default defineConfig((/* ctx */) => {
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#framework
     framework: {
-      config: {},
+      config: {
+        dark: true,
+      },
 
       // iconSet: 'material-icons', // Quasar icon set
       // lang: 'en-US', // Quasar language pack

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -1,5 +1,7 @@
 // app global css in SCSS form
 body {
-  background: linear-gradient(180deg, #292d3e 0%, #1b1e2b 100%);
+  min-height: 100vh;
+  background: linear-gradient(135deg, #1b1e2b 0%, #292d3e 100%);
+  background-attachment: fixed;
   color: #ffffff;
 }

--- a/frontend/src/css/quasar.variables.scss
+++ b/frontend/src/css/quasar.variables.scss
@@ -12,6 +12,8 @@
 // to match your app's branding.
 // Tip: Use the "Theme Builder" on Quasar's documentation website.
 
+// Palenight color palette
+
 $primary: #82aaff;
 $secondary: #c792ea;
 $accent: #f78c6c;

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,8 +1,8 @@
 <template>
   <q-layout view="lHh Lpr lFf">
-    <q-header elevated>
+    <q-header elevated class="header-gradient text-white">
       <q-toolbar>
-        <q-toolbar-title>Der dümmste fliegt</q-toolbar-title>
+        <q-toolbar-title class="text-h5">Der dümmste fliegt</q-toolbar-title>
       </q-toolbar>
     </q-header>
     <q-page-container>
@@ -15,3 +15,9 @@
 <script setup>
 import EmoteOverlay from 'components/EmoteOverlay.vue'
 </script>
+
+<style scoped lang="scss">
+.header-gradient {
+  background: linear-gradient(135deg, #292d3e 0%, #1b1e2b 100%);
+}
+</style>


### PR DESCRIPTION
## Summary
- enable dark mode in Quasar configuration
- add palenight gradient backgrounds for body and header
- document palenight color palette variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70f66b05c8322a18d7d8962b6f0a4