### PR TITLE
feat: apply palenight dark theme

### DIFF
--- a/frontend/quasar.config.js
+++ b/frontend/quasar.config.js
@@ -86,7 +86,9 @@ export default defineConfig((/* ctx */) => {
 
     // https://v2.quasar.dev/quasar-cli-vite/quasar-config-file#framework
     framework: {
-      config: {},
+      config: {
+        dark: true,
+      },
 
       // iconSet: 'material-icons', // Quasar icon set
       // lang: 'en-US', // Quasar language pack

--- a/frontend/src/css/app.scss
+++ b/frontend/src/css/app.scss
@@ -1,5 +1,9 @@
 // app global css in SCSS form
-body {
+.palenight-gradient {
   background: linear-gradient(180deg, #292d3e 0%, #1b1e2b 100%);
+}
+
+body {
+  @extend .palenight-gradient;
   color: #ffffff;
 }

--- a/frontend/src/layouts/MainLayout.vue
+++ b/frontend/src/layouts/MainLayout.vue
@@ -1,6 +1,6 @@
 <template>
-  <q-layout view="lHh Lpr lFf">
-    <q-header elevated>
+  <q-layout view="lHh Lpr lFf" class="palenight-gradient text-white">
+    <q-header elevated class="palenight-gradient">
       <q-toolbar>
         <q-toolbar-title>Der dümmste fliegt</q-toolbar-title>
       </q-toolbar>


### PR DESCRIPTION
## Summary
- add reusable palenight gradient and use it for layout and header
- enable Quasar dark mode

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a70f66b05c8322a18d7d8962b6f0a4